### PR TITLE
Fix inline element

### DIFF
--- a/src/WBApexTool.ts
+++ b/src/WBApexTool.ts
@@ -257,11 +257,10 @@ export default class WBApexTool {
 
     if(this.wbSession.getSelectedElement().tagName == 'DIV') {
       tempIndex = Array.from(document.getElementsByTagName('DIV')).indexOf(this.wbSession.getSelectedElement()) - document.querySelector('#webuffet-components').querySelectorAll(this.wbSession.getSelectedElement().tagName).length - 1
-    } else if (this.wbSession.getSelectedElement().tagName == 'SPAN') {
-      tempIndex = Array.from(document.getElementsByTagName('SPAN')).indexOf(this.wbSession.getSelectedElement()) - document.querySelector('#webuffet-components').querySelectorAll(this.wbSession.getSelectedElement().tagName).length
     } else {
-      tempIndex = Array.from(document.getElementsByTagName(this.wbSession.getSelectedElement().tagName)).indexOf(this.wbSession.getSelectedElement())
+      tempIndex = Array.from(document.getElementsByTagName(this.wbSession.getSelectedElement().tagName)).indexOf(this.wbSession.getSelectedElement()) - document.querySelector('#webuffet-components').querySelectorAll(this.wbSession.getSelectedElement().tagName).length
     }
+
     if(this.wbSession.getSelectedElement().className.includes(' ') == true) {
       tempCName = ""
     } else {

--- a/src/WBApexTool.ts
+++ b/src/WBApexTool.ts
@@ -48,7 +48,7 @@ export default class WBApexTool {
     this.syncStorage()
 
     // Add apex tool triggering event listener
-    document.addEventListener('webuffetscan', this.start.bind(this))
+    document.addEventListener('webuffetscanend', this.start.bind(this))
     document.addEventListener('needstoragesync', this.syncStorage.bind(this))
   }
 

--- a/src/WBSelector.ts
+++ b/src/WBSelector.ts
@@ -37,7 +37,7 @@ export default class WBSelector {
       this.stop()
       this.wbSession.setOriginal(this.hoverElm)
 
-      document.dispatchEvent(new CustomEvent('webuffetscan'))
+      document.dispatchEvent(new CustomEvent('webuffetscanend'))
     })
   }
 

--- a/src/WBSession.ts
+++ b/src/WBSession.ts
@@ -43,6 +43,9 @@ export default class WBSession {
   }
 
   setOriginal(elm: HTMLElement) {
+    if (window.getComputedStyle(elm).display === 'inline') {
+      elm.style.display = 'inline-block'
+    }
     this.selectedElm = elm
     const rect = elm.getBoundingClientRect()
     html2canvas(this.selectedElm, {


### PR DESCRIPTION
#50 

Inline elements are not governed by CSS box model. So their display property should be converted to 'inline-block' which acts like 'inline' but is box-level. I temporarily fixed the wrong boundary selection of `WBSelector` on inline elements by changing to inline-block, yet it will not working after reloads. We should update this later.