### PR TITLE
Fix error that some pages become blank

### DIFF
--- a/src/HideHtml.ts
+++ b/src/HideHtml.ts
@@ -18,65 +18,70 @@ window.onload = () => {
         * Get URL first, check the URL matches with document.URL
         * If matches, find elements in document with name and generate CSS for that element with style
         */
-        if(!items.myCustom[0]) {
-            body.style.opacity = '1'
-            return
-        }
-        
-        else {
-            let srcElm = document.createElement('div')
-            srcElm.id = 'webuffet-image-sources'
-            document.body.appendChild(srcElm)
-            let imgSrcArr: Array<String> = []
 
-            let processElement = function (items: any, i: number) {
-                if (i == items.myCustom.length) {
-                    // body.style.transform = ''
-                    body.style.opacity = '1'
-                    return
-                }
-                let num : number = i
-                let item = items.myCustom[i]
-                let element: HTMLElement
-                if(item.url != document.URL) {
-                    if (i > items.myCustom.length - 1) {
-                        body.style.opacity = '1'
-                    }
-                    imgSrcArr.push('null')
-                    srcElm.setAttribute('data', JSON.stringify(imgSrcArr))
-                    processElement(items, i+1)
-                    return
-                }
-                
-                
-                if(item.name.id != "") {
-                    element = document.getElementById(item.name.id)
-                } else if(item.name.cName != "") {
-                    element = document.getElementsByClassName(item.name.cName).item(item.name.cIndex) as HTMLElement
-                } else {
-                    element = document.getElementsByTagName(item.name.tName).item(item.name.tIndex) as HTMLElement
-                }
-                
-                html2canvas(element, {
-                    useCORS: true,
-                    backgroundColor: null,
-                  }).then((canvas: HTMLCanvasElement) => {
-                    imgSrcArr[num] = canvas.toDataURL('image/png')
-                    srcElm.setAttribute('data', JSON.stringify(imgSrcArr))
-                    if(item.style.isDeleted == true) {
-                        element.style.display = 'none'
-                    } else {
-                        element.style.transform = Ruler.generateCSS(item.style.translatex, item.style.translatey, item.style.scale, item.style.rotate)
-                    }
-                    if(i > items.myCustom.length - 1) {
-                        body.style.opacity = '1'
-                    }
-
-                    processElement(items, i + 1)
-                })
+        try {
+            if(!items.myCustom[0]) {
+                body.style.opacity = '1'
+                return
             }
 
-            processElement(items, 0)
+            else {
+                let srcElm = document.createElement('div')
+                srcElm.id = 'webuffet-image-sources'
+                document.body.appendChild(srcElm)
+                let imgSrcArr: Array<String> = []
+
+                let processElement = function (items: any, i: number) {
+                    if (i == items.myCustom.length) {
+                        // body.style.transform = ''
+                        body.style.opacity = '1'
+                        return
+                    }
+                    let num : number = i
+                    let item = items.myCustom[i]
+                    let element: HTMLElement
+                    if(item.url != document.URL) {
+                        if (i > items.myCustom.length - 1) {
+                            body.style.opacity = '1'
+                        }
+                        imgSrcArr.push('null')
+                        srcElm.setAttribute('data', JSON.stringify(imgSrcArr))
+                        processElement(items, i+1)
+                        return
+                    }
+
+
+                    if(item.name.id != "") {
+                        element = document.getElementById(item.name.id)
+                    } else if(item.name.cName != "") {
+                        element = document.getElementsByClassName(item.name.cName).item(item.name.cIndex) as HTMLElement
+                    } else {
+                        element = document.getElementsByTagName(item.name.tName).item(item.name.tIndex) as HTMLElement
+                    }
+
+                    html2canvas(element, {
+                        useCORS: true,
+                        backgroundColor: null,
+                    }).then((canvas: HTMLCanvasElement) => {
+                        imgSrcArr[num] = canvas.toDataURL('image/png')
+                        srcElm.setAttribute('data', JSON.stringify(imgSrcArr))
+                        if(item.style.isDeleted == true) {
+                            element.style.display = 'none'
+                        } else {
+                            element.style.transform = Ruler.generateCSS(item.style.translatex, item.style.translatey, item.style.scale, item.style.rotate)
+                        }
+                        if(i > items.myCustom.length - 1) {
+                            body.style.opacity = '1'
+                        }
+
+                        processElement(items, i + 1)
+                    })
+                }
+
+                processElement(items, 0)
+            }
+        } finally {
+            body.style.opacity = '1'
         }
     })
 }


### PR DESCRIPTION
1. Related to #54
Some sites(e.g. youtube) become blank when an exception occurs in webuffet. The reason is that webuffet initially set opacity = '0'. If an exception occurs, the opacity is never back to 1. This PR has fixed the problem. The codes guarantee that opacity must be back to 1. But this PR doesn't fix the source of Exception. Because it is more hard to fix, and it is related to the site's html structure. Currently I think it is ok to use this patch.
